### PR TITLE
Don't use the VPC's main route table for private subnets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ terraform.tfstate*
 Gemfile.lock
 .ruby-version
 *.auto.tfvars
+.terraform.lock.hcl

--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,0 +1,48 @@
+content: |
+  # Terraform module - AWS basic network
+
+  A terraform module that deploys a VPC and two types of subnets.
+
+  ## Usage
+
+  It is the user's responsibility to calculate the CIDRs for the VPC and subnets so that they are sensible.
+
+  The subnet types are designated **public** and **private**.
+
+  * The **"public"** subnets allow for resources in it to be reachable from the internet.
+  * The **"private"** subnets do not allow incoming connections from the internet, but still allow outbound connections from the resources in it.
+
+  **Notes:**
+
+  * The input variables that define the subnets to be created - `public_subnet_cidrs` and `private_subnet_cidrs` are actually maps and not lists of CIDRs as one might expect. The keys of the map define the CIDRs of the subnets while the values define the availability zone in which the subnet will be created. These values are of type `number` and they are used as an index to select an availability zone form the list of zones for the current AWS region.
+
+  * To allow connectivity for the **private** subnets an `aws_nat_gateway` is created in the first public subnet in the list. Therefore the **public** subnet list can never  be with `0` elements. If the **private** subnets list is empty the `aws_nat_gateway` and its associated resources will not be crated as well.
+
+  {{ .Inputs }}
+
+  {{ .Outputs }}
+
+  {{ .Requirements }}
+
+  {{ .Resources }}
+
+  ## Documentation
+
+  Generated with [terraform-docs](https://terraform-docs.io/user-guide/introduction/). 
+  ```bash
+  terraform-docs markdown table . -c .terraform-docs.yaml > README.md
+  ```
+settings:
+  anchor: false
+  color: true
+  default: true
+  description: false
+  escape: false
+  hide-empty: true
+  html: false
+  indent: 2
+  lockfile: false
+  read-comments: true
+  required: true
+  sensitive: true
+  type: true

--- a/ouput.tf
+++ b/ouput.tf
@@ -25,7 +25,12 @@ output "vpc_id" {
 
 output "main_route_table_id" {
   value       = aws_vpc.main.main_route_table_id
-  description = "The id of the VPC default routing table. Used by the private subnets"
+  description = "The id of the VPC default routing table. It is not used by any subnets."
+}
+
+output "private_route_table_id" {
+  value       = try(aws_route_table.private[0].id, "")
+  description = "The id of the privagte routing table. Used by the private subnets."
 }
 
 output "public_route_table_id" {

--- a/routing.tf
+++ b/routing.tf
@@ -53,9 +53,32 @@ resource "aws_nat_gateway" "gw" {
   )
 }
 
-resource "aws_route" "default_nat_gw" {
-  count                  = local.isNATGW ? 1 : 0
-  route_table_id         = aws_vpc.main.main_route_table_id
-  destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id         = aws_nat_gateway.gw[0].id
+resource "aws_route_table" "private" {
+  count  = local.isNATGW ? 1 : 0
+  vpc_id = aws_vpc.main.id
+  tags = merge({
+    Name = "${var.name_prefix}default-nat-rtb"
+    },
+    var.common_tags
+  )
 }
+
+resource "aws_route" "default_private" {
+  count                  = local.isNATGW ? 1 : 0
+  route_table_id         = aws_route_table.private[0].id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_nat_gateway.gw[0].id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each       = local.isNATGW ? aws_subnet.private : {}
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private[0].id
+}
+
+# resource "aws_route" "default_nat_gw" {
+#   count                  = local.isNATGW ? 1 : 0
+#   route_table_id         = aws_vpc.main.main_route_table_id
+#   destination_cidr_block = "0.0.0.0/0"
+#   nat_gateway_id         = aws_nat_gateway.gw[0].id
+# }

--- a/test/fixtures/ec2-test-instances.tf
+++ b/test/fixtures/ec2-test-instances.tf
@@ -28,7 +28,7 @@ resource "aws_security_group" "allow-all" {
 resource "aws_instance" "public" {
   count                       = length(module.wc_network.public_subnet_ids)
   subnet_id                   = module.wc_network.public_subnet_ids[count.index]
-  ami                         = data.aws_ami.ubuntu-xenial.image_id
+  ami                         = data.aws_ami.ubuntu-focal.image_id
   vpc_security_group_ids      = [aws_security_group.allow-all.id]
   key_name                    = aws_key_pair.kitchen-test.id
   associate_public_ip_address = true
@@ -39,7 +39,7 @@ resource "aws_instance" "public" {
 resource "aws_instance" "private" {
   count                       = length(module.wc_network.private_subnet_ids)
   subnet_id                   = module.wc_network.private_subnet_ids[count.index]
-  ami                         = data.aws_ami.ubuntu-xenial.image_id
+  ami                         = data.aws_ami.ubuntu-focal.image_id
   vpc_security_group_ids      = [aws_security_group.allow-all.id]
   key_name                    = aws_key_pair.kitchen-test.id
   associate_public_ip_address = true
@@ -47,13 +47,13 @@ resource "aws_instance" "private" {
   tags                        = var.common_tags
 }
 
-data "aws_ami" "ubuntu-xenial" {
+data "aws_ami" "ubuntu-focal" {
   most_recent = "true"
   owners      = ["099720109477"]
 
   filter {
     name   = "name"
-    values = ["ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-*"]
+    values = ["ubuntu/images/hvm-ssd/ubuntu-focal-*-amd64-server-*"]
   }
 
   filter {


### PR DESCRIPTION
The module will now create a dedicated route table to be used by the private subnets. The private subnets will no longer use the VPC's main route table, nor a default route through the NAT gateway will be configured for it.